### PR TITLE
Fix the obsolete link to bitbucket

### DIFF
--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -4,8 +4,8 @@
 
 If you would like to contribute to sphinxcontrib.sqltable directly,
 these instructions should help you get started.  Patches, bug reports,
-and feature requests are all welcome through the `BitBucket site
-<https://bitbucket.org/dhellmann/sphinxcontrib-sqltable/>`__.
+and feature requests are all welcome through the `Github
+<https://github.com/sphinx-contrib/sqltable/>`__.
 Contributions in the form of patches or pull requests are easier to
 integrate and will receive priority attention.
 


### PR DESCRIPTION
Point to Github instead of BitBucket